### PR TITLE
Add an option to be able to plug a custom Python function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -532,3 +532,5 @@ data/
 *.jpeg
 *.bmp
 *.gif
+.mypy_cache/
+install_log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "3.5"
 
 install: 
+    - sudo apt-get install python-dbus
     - pip install -r requirements.txt
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ init:
 
 .PHONY: install
 install:
-	@./setup.py install
+	@./setup.py install --optimize=1 --record=install_log.txt
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ check:
 
 .PHONY: coverage
 coverage:
-	@coverage run --source design -m py.test
+	@coverage run --source cmus_notify -m py.test
 	@coverage report
 
 .PHONY: test
@@ -41,7 +41,7 @@ man: doc
 clean:
 	@rm -rf dist/
 	@rm -rf build/
-	@rm -rf design.egg-info/
+	@rm -rf cmus_notify.egg-info/
 	@find . -name '*.pyc' -exec rm {} \;
 	@find . -name '__pycache__' -exec rm -rf {} \;
 	@rm -rf samples/

--- a/README.rst
+++ b/README.rst
@@ -81,11 +81,12 @@ You can also specify a configuration to read these values from. By default, the 
 
     [notifications]
         application_name = Cmus
+        custom_notification = /home/user/.cmus/custom_notification.py
 
     [format]
         title = Now playing: {title} by {artist}
         body = <b>Album:</b> {album}
-            <b>Duration:</b> {duration}
+               <b>Duration:</b> {duration}
 
 The options accepts the same values as their command-line options equivalent.
 
@@ -102,8 +103,9 @@ which will display the following prompt:
 
 ::
 
-    usage: cmus_notify [-h] [-a APPLICATION_NAME] [-b BODY_FORMAT_STRING]
+    usage: cmus_notify [-h] [-a APPLICATION_NAME] [- BODY_FORMAT_STRING]
                        [-t TITLE_FORMAT_STRING] [-f CONFIGURATION_FILE]
+                       [-c CUSTOM_NOTIFICATION]
                        INFORMATION
 
     Display a notification about Cmus's current status
@@ -131,6 +133,11 @@ which will display the following prompt:
                             The path to the configuration file. If it is not
                             specified, the program will use the default values of
                             the other options.
+      -c CUSTOM_NOTIFICATION, --custom_notification CUSTOM_NOTIFICATION
+                            The path to a custom implementation of the
+                            notification class. If it is not specified, the
+                            standard implementation will be used (the one using
+                            notify2).
 
     Format String Parameters
     ========================

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,12 @@
 cmus-notify
 ===========
 
+.. image:: https://travis-ci.org/AntoineGagne/cmus-notify.svg?branch=master
+    :target: https://travis-ci.org/AntoineGagne/cmus-notify
+
+.. image:: https://img.shields.io/pypi/v/cmus-notify.svg
+        :target: https://pypi.python.org/pypi/cmus-notify
+
 :Author: `Antoine Gagné <antoine.gagne.2@ulaval.ca>`_
 
 .. contents::

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ which will display the following prompt:
 
 ::
 
-    usage: cmus_notify [-h] [-a APPLICATION_NAME] [- BODY_FORMAT_STRING]
+    usage: cmus_notify [-h] [-a APPLICATION_NAME] [-b BODY_FORMAT_STRING]
                        [-t TITLE_FORMAT_STRING] [-f CONFIGURATION_FILE]
                        [-c CUSTOM_NOTIFICATION]
                        INFORMATION

--- a/cmus_notify/cmus_notify.py
+++ b/cmus_notify/cmus_notify.py
@@ -1,9 +1,10 @@
 """Contains the main code of the package."""
 
+import importlib
+import os
+import sys
+
 from .configurations import parse_configuration_file
-from .constants import ICONS_BY_STATUS
-from .formatters import format_notification_message
-from .notifications import Notifier
 from .parsers import parse_status_information
 
 
@@ -11,12 +12,23 @@ def main():
     """Main entry point of the package."""
     arguments = parse_configuration_file()
     information = parse_status_information(arguments['parse'])
-    title, text = format_notification_message(information,
-                                              title=arguments['title'],
-                                              body=arguments['body'])
-    notifier = Notifier(arguments['application_name'])
-    notifier.send_notification(
-        title,
-        text,
-        icon_path=ICONS_BY_STATUS.get(information.status.lower(), '')
-    )
+    custom_notifier = load_notifier(arguments)
+    custom_notifier(arguments, information)
+
+
+def load_notifier(arguments):
+    """Load the custom notification module.
+
+    :param arguments: The parsed arguments
+    :returns: The notifier to be used for the notifications
+    """
+    custom_notifier_path = arguments['custom_notification']
+    if custom_notifier_path:
+        sys.path.insert(0, os.path.expanduser(os.path.dirname(custom_notifier_path)))
+        notifier_module = importlib.import_module(os.path.basename(custom_notifier_path))
+        notifier = notifier_module.send_notification
+    else:
+        from .notifications import send_notification
+        notifier = send_notification
+
+    return notifier

--- a/cmus_notify/constants.py
+++ b/cmus_notify/constants.py
@@ -1,5 +1,6 @@
 """Contains the constants used by the library."""
 
+
 #: Default text for the display values
 DEFAULT_STATUS_DISPLAY = 'N/A'
 #: The various field contained in the metadata

--- a/cmus_notify/notifications.py
+++ b/cmus_notify/notifications.py
@@ -2,37 +2,27 @@
 
 import notify2
 
-from .constants import DEFAULT_ICON_PATH, DEFAULT_TIMEOUT
+from .constants import (DEFAULT_ICON_PATH,
+                        DEFAULT_TIMEOUT,
+                        ICONS_BY_STATUS)
+from .formatters import format_notification_message
 
 
-class Notifier:
-    """Notifies the system with a notification.
-    
-    .. note:: Currently, it only works on Linux
+def send_notification(arguments, information):
+    """Send the notification to the OS with a Python library.
+
+    :param arguments: The parsed arguments
+    :param information: The various song informations
     """
-
-    def __init__(self, application_name):
-        """Initialize a :class:`cmus_notify.notifications.Notifier` object.
-
-        :param application_name: The application's name
-        :type application_name: str
-        """
-        self.application_name = application_name
-
-    def send_notification(self, title, text, **kwargs):
-        """Send the notification to the OS with a Python library.
-
-        :param title: The message's title
-        :type title: str
-        :param text: The message's body
-        :type text: str
-        """
-        notify2.init(self.application_name)
-        notification = notify2.Notification(
-            title,
-            text,
-            kwargs.get('icon_path', DEFAULT_ICON_PATH)
-        )
-        notification.set_urgency(kwargs.get('urgency', notify2.URGENCY_LOW))
-        notification.timeout = kwargs.get('timeout', DEFAULT_TIMEOUT)
-        notification.show()
+    notify2.init(arguments['application_name'])
+    title, text = format_notification_message(information,
+                                              title=arguments['title'],
+                                              body=arguments['body'])
+    notification = notify2.Notification(
+        title,
+        text,
+        ICONS_BY_STATUS.get('icon_path', DEFAULT_ICON_PATH)
+    )
+    notification.set_urgency(arguments.get('urgency', notify2.URGENCY_LOW))
+    notification.timeout = arguments.get('timeout', DEFAULT_TIMEOUT)
+    notification.show()

--- a/cmus_notify/notifications.py
+++ b/cmus_notify/notifications.py
@@ -1,7 +1,5 @@
 """Contains code related to notifications."""
 
-import notify2
-
 from .constants import (DEFAULT_ICON_PATH,
                         DEFAULT_TIMEOUT,
                         ICONS_BY_STATUS)
@@ -14,6 +12,8 @@ def send_notification(arguments, information):
     :param arguments: The parsed arguments
     :param information: The various song informations
     """
+    import notify2
+
     notify2.init(arguments['application_name'])
     title, text = format_notification_message(information,
                                               title=arguments['title'],

--- a/cmus_notify/options.py
+++ b/cmus_notify/options.py
@@ -66,4 +66,13 @@ def parse_arguments():
                         help='The path to the configuration file. If it is not '
                              'specified, the program will use the default '
                              'values of the other options.')
+    parser.add_argument('-c',
+                        '--custom_notification',
+                        required=False,
+                        default=SUPPRESS,
+                        type=str,
+                        help='The path to a custom implementation of the '
+                             'notification class. If it is not specified, the '
+                             'standard implementation will be used (the one using '
+                             'notify2).')
     return parser.parse_args()


### PR DESCRIPTION
As the title says, it will now be possible to specify a module to import containing a Python function named `send_notification` that will be imported by the program instead of the standard notification hook.