### PR TITLE
If no configuration file is present do not crash.

### DIFF
--- a/cmus_notify/cmus_notify.py
+++ b/cmus_notify/cmus_notify.py
@@ -22,7 +22,7 @@ def load_notifier(arguments):
     :param arguments: The parsed arguments
     :returns: The notifier to be used for the notifications
     """
-    custom_notifier_path = arguments['custom_notification']
+    custom_notifier_path = arguments.get('custom_notification', None)
     if custom_notifier_path:
         sys.path.insert(0, os.path.expanduser(os.path.dirname(custom_notifier_path)))
         notifier_module = importlib.import_module(os.path.basename(custom_notifier_path))


### PR DESCRIPTION
If no configuration file was found, the direct access to the key would
raise an exception, not catched. Using the get method fixes this.